### PR TITLE
Scripts/add hideme

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,0 +1,2 @@
+alias hideme=". hideme"
+

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ Basic settings to save time configuring a new machine
 - `cpb` - Copy branch name to clipboard
 - `sep` - Print a separator
 - `purgespm` - Delete local and global caches of Swift Package Manager, including derived data and security fingerprints
+- `hideme` - Hides current user and host name from terminal prompt and pwd. Needs to be sourced (for example, like in `.zshrc`)

--- a/scripts/hideme
+++ b/scripts/hideme
@@ -1,0 +1,6 @@
+#!/bin/zsh
+
+export PROMPT="me@mac %1~ %# "
+
+alias pwd="pwd|sed s/$(whoami)/me/"
+


### PR DESCRIPTION
In this PR:
- added `hideme` script that hides user/machine from the prompt (for example, when screensharing)
- added a `.zshrc` config that `source`s the `hideme` script
- updated the README file with the description of `hideme`