### PR TITLE
Use leader with vim wrapping remaps in visual mode

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -31,13 +31,15 @@ nnoremap <leader>{ viwdi{}<C-[>hp
 nnoremap <leader>" viwdi""<C-[>hp
 nnoremap <leader>' viwdi''<C-[>hp
 nnoremap <leader>` viwdi``<C-[>hp
+nnoremap <leader>< viwdi<><C-[>hp
 " Enclose selection 
-vnoremap ( di()<C-[>hp
-vnoremap [ di[]<C-[>hp
-vnoremap { di{}<C-[>hp
-vnoremap " di""<C-[>hp
-vnoremap ' di''<C-[>hp
-vnoremap ` di``<C-[>hp
+vnoremap <leader>( di()<C-[>hp
+vnoremap <leader>[ di[]<C-[>hp
+vnoremap <leader>{ di{}<C-[>hp
+vnoremap <leader>" di""<C-[>hp
+vnoremap <leader>' di''<C-[>hp
+vnoremap <leader>` di``<C-[>hp
+vnoremap <leader>< di<><C-[>hp
 
 " Move selected lines
 vnoremap J :m '>+1<CR>gv


### PR DESCRIPTION
In this PR:
- vim: add `leader` before enclosing commands in visual mode
- vim: add one more remap for `<>`