### PR TITLE
Add mkdj and a convenience remap for :Rex

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -21,8 +21,9 @@ set autoindent
 " Set leader
 let mapleader = " "
 
-" Exit to netrw explorer
+" Exit to netrw explorer and go back
 nnoremap <leader>e :Ex<CR>
+nnoremap <leader>r :Rex<CR>
 
 " Enclose word in normal mode 
 nnoremap <leader>( viwdi()<C-[>hp

--- a/.zshrc
+++ b/.zshrc
@@ -1,2 +1,7 @@
 alias hideme=". hideme"
 
+# Make directory and jump into it
+function mkdj {
+    mkdir $1 && cd $1
+}
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ Basic settings to save time configuring a new machine
 - `sep` - Print a separator
 - `purgespm` - Delete local and global caches of Swift Package Manager, including derived data and security fingerprints
 - `hideme` - Hides current user and host name from terminal prompt and pwd. Needs to be sourced (for example, like in `.zshrc`)
+
+## Commands
+- `mkdj` - Make directory and jump into it, convenience function in `.zshrc`


### PR DESCRIPTION
In this PR:
- in .vimrc: add missing remap for `<leader>r` to return back to file from netrw in normal mode
- in .zshrc: add `mkdj` function that creates a directory and jumps into it
- added small description for `mkdj` to README