### PR TITLE
Make some of the scripts usable with sh

### DIFF
--- a/scripts/cpb
+++ b/scripts/cpb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 GREEN="\033[32m"
 CYAN="\033[36m"
@@ -16,9 +16,9 @@ done
 BRANCH=$(git branch --show-current | tr -d '\n')
 
 if [ -n "${BRANCH}" ]; then
-    echo -n "${BRANCH}" | pbcopy
+    printf "${BRANCH}" | pbcopy
     if [ "${IS_QUIET_MODE}" = false ]; then
-        echo -e "${GREEN}Branch name ${CYAN}${BRANCH}${GREEN} copied to clipboard!${CLEAR}"
+        printf "${GREEN}Branch name ${CYAN}${BRANCH}${GREEN} copied to clipboard!${CLEAR}\n"
     fi
 fi
 

--- a/scripts/nvimconfig
+++ b/scripts/nvimconfig
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 CURRENT_USER=$(whoami)
 

--- a/scripts/sep
+++ b/scripts/sep
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 BLACK=30
 RED=31
@@ -19,10 +19,7 @@ function first_char {
 }
 
 # Check color
-if [[ $1 = [30-39] ]]; then
- COLOR="$COLOR_ARG"
-
-elif [ "$COLOR_ARG" = "black" ]; then
+if [ "$COLOR_ARG" = "black" ]; then
  COLOR=$BLACK
 
 elif [ "$(first_char)" = "g" ]; then
@@ -50,7 +47,7 @@ fi
 
 # Check text type
 if [ "$2" = "blink" ]; then
- BLINK='$;'
+ BLINK=';5'
 fi
 
 # Read width of the terminal window
@@ -59,9 +56,9 @@ COLS=$(tput cols)
 # Print the separator
 LINE=""
 
-for ((i = 0; i < $COLS; i++ )); do
-    LINE+="-"
+for i in $(seq 1 $COLS); do 
+    LINE="${LINE}-"
 done
 
-echo -e "\033[0;${COLOR}${BLINK}m${LINE}$(tput sgr0)"
+printf "\033[0;${COLOR}${BLINK}m${LINE}$(tput sgr0)\n"
 


### PR DESCRIPTION
I need as many of my tools usable from different macOS versions and Linux distributives as possible, that's why I'm porting some of them into `sh` shell, which is the most common shell.

### In this PR:
- made the following scripts usable from `sh` shell: `cpb`, `nvimconfig`, `sep`
- removed the option of using number arguments for colors from the `sep` command, since I haven't ever actually used them but it's harder to maintain when porting between shells