### PR TITLE
Add remap for HTML template

### DIFF
--- a/.config/nvim/lua/currentuser/remap.lua
+++ b/.config/nvim/lua/currentuser/remap.lua
@@ -46,3 +46,13 @@ vim.keymap.set("v", "<leader>p", "\"+p")
 -- Add empty line in normal mode
 vim.keymap.set("n", "<leader>o", "o<Esc>")
 vim.keymap.set("n", "<leader>O", "O<Esc>")
+
+-- Add empty HTML template in normal mode
+vim.keymap.set("n", "<leader>html", "i<!Doctype HTML>\
+<html lang=\"en\">\
+<head>\
+<title></title>\
+</head>\
+<body>\
+</body>\
+</html><Esc>4k3wa")

--- a/.vimrc
+++ b/.vimrc
@@ -69,3 +69,5 @@ vnoremap <leader>p "+p
 nnoremap <leader>o o<Esc>
 nnoremap <leader>O O<Esc>
 
+" Add empty HTML template in normal mode
+nnoremap <leader>html i<!Doctype HTML><CR><html lang="en"><CR>    <head><CR>    <title></title><CR><BS></head><CR><body><CR></body><CR><BS></html><Esc>4k3wa


### PR DESCRIPTION
In this PR:
- added a remap that will paste a simple empty HTML template on `<leader>html` remap to both vim and neovim configs
- made neovim html remap multiline

For neovim it will work well in case the HTML syntax is picked up (like when pasting in an .html file by default).