### PR TITLE
Use classic colors for Neovim

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,3 +1,5 @@
 require("currentuser.remap")
 require("currentuser.set")
 
+-- Set the classic colorscheme
+vim.cmd("colorscheme vim")

--- a/.config/nvim/lua/currentuser/set.lua
+++ b/.config/nvim/lua/currentuser/set.lua
@@ -13,3 +13,6 @@ vim.opt.shiftwidth = 4
 vim.opt.softtabstop = 4
 
 vim.opt.autoindent = true
+
+-- Disable true colors
+vim.opt.termguicolors = false


### PR DESCRIPTION
In this PR:
- since the newer version of Neovim breaks the old color scheme for syntax highlighting, turned off true colors and set the classic Vim color scheme