### PR TITLE
Prevent gst from proceeding if git status failed

### DIFF
--- a/scripts/gst
+++ b/scripts/gst
@@ -10,7 +10,7 @@ GIT_OUTPUT=$(GIT_PAGER=cat git -c color.status=always status)
 
 # Exit if output is empty
 if [ -z "${GIT_OUTPUT}" ]; then
-  exit
+  exit 1
 fi
 
 # Extract the branch name

--- a/scripts/gst
+++ b/scripts/gst
@@ -8,6 +8,11 @@ CLEAR="\033[0m"
 # Capture the output of 'git status' command with color enabled
 GIT_OUTPUT=$(GIT_PAGER=cat git -c color.status=always status)
 
+# Exit if output is empty
+if [ -z "${GIT_OUTPUT}" ]; then
+  exit
+fi
+
 # Extract the branch name
 BRANCH=$(echo "${GIT_OUTPUT}" | grep 'On branch' | awk '{print $3}')
 


### PR DESCRIPTION
In this PR:
- added a check to prevent further execution if there was no successful output from `git status` command