### PR TITLE
Move fetchall script into the toolkit repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ Basic settings to save time configuring a new machine
 
 ## Scripts
 - `cpb` - Copy branch name to clipboard
-- `sep` - Print a separator
+- `fetchall` - Fetches all the repos in the repos directory. For now, need to replace the `$REPOS_DIR` to point to the custom directory where the repose are stored.
 - `gst` - "**g**it **st**atus" but shorter and the branch name is highlighted
-- `purgespm` - Delete local and global caches of Swift Package Manager, including derived data and security fingerprints
 - `hideme` - Hide current user and host name from terminal prompt and pwd. Needs to be sourced (for example, like in `.zshrc`)
 - `nvimconfig` - Install Neovim configs into `~/.config` directory and set its user config subdirectory to the current user. Convenience script, __should run from the `scripts` directory.__
-- `fetchall` - Fetches all the repos in the repos directory. For now, need to replace the `$REPOS_DIR` to point to the custom directory where the repose are stored.
+- `purgespm` - Delete local and global caches of Swift Package Manager, including derived data and security fingerprints
+- `sep` - Print a separator
 
 ## Commands
 - `mkdj` - Make directory and jump into it, convenience function in `.zshrc`

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Basic settings to save time configuring a new machine
 - `purgespm` - Delete local and global caches of Swift Package Manager, including derived data and security fingerprints
 - `hideme` - Hide current user and host name from terminal prompt and pwd. Needs to be sourced (for example, like in `.zshrc`)
 - `nvimconfig` - Install Neovim configs into `~/.config` directory and set its user config subdirectory to the current user. Convenience script, __should run from the `scripts` directory.__
+- `fetchall` - Fetches all the repos in the repos directory. For now, need to replace the `$REPOS_DIR` to point to the custom directory where the repose are stored.
 
 ## Commands
 - `mkdj` - Make directory and jump into it, convenience function in `.zshrc`

--- a/scripts/fetchall
+++ b/scripts/fetchall
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DIV="--------------------------"
+PRUNE=""
+
+# Directory where all the repos are stored, update if needed
+REPOS_DIR="{HOME}/repos"
+
+while getopts "p" OPTION; do
+    case $OPTION in
+        p)
+            PRUNE="-p"
+            ;;
+    esac
+done
+
+echo "FETCH ALL REPOS\n\
+in the directory: ${REPOS_DIR}"
+
+for REPO in $(ls $REPOS_DIR); do
+    echo "$DIV"
+    cd "$REPOS_DIR/$REPO"
+    echo "Fetching repo: $REPO..."
+    git fetch $PRUNE
+done


### PR DESCRIPTION
In this PR:
- moved the `fetchall` script "as-is" into this repo 
- mentioned it in the README
- updated the order of the scripts descriptions sorted by name