### PR TITLE
Remove dots from user name to fix Lua imports

### DIFF
--- a/scripts/nvimconfig
+++ b/scripts/nvimconfig
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CURRENT_USER=$(whoami|sed -i.bak "s/.//g")
+CURRENT_USER=$(whoami|sed "s/\.//g")
 
 # Path where Neovim config will be stored by default
 CONFIG_TARGET_PATH="${HOME}/.config/nvim"

--- a/scripts/nvimconfig
+++ b/scripts/nvimconfig
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CURRENT_USER=$(whoami)
+CURRENT_USER=$(whoami|sed -i.bak "s/.//g")
 
 # Path where Neovim config will be stored by default
 CONFIG_TARGET_PATH="${HOME}/.config/nvim"


### PR DESCRIPTION
In this PR:
- when getting the current user name in the `nvimconfig` script, used `sed` to remove the `.` character, since Lua require statement sees it as a subdirectory  

For example, if the user name was `current.user`, Lua would try importing the `current.user/remap.lua` file at ` current/user/remap.lua`.  
Now the user config directory for `current.user` will be set to `currentuser`, and the same will be used in the "require" statement in the `init.lua`.