### PR TITLE
Add Lua LSP for Neovim

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -72,7 +72,10 @@ if is_installed("lua-language-server") then
           globals = { "vim" },
         },
         workspace = {
-          library = vim.api.nvim_get_runtime_file("", true),
+          library = {
+            vim.fn.stdpath("config") .. "/lua/currentuser",
+            "/usr/share/nvim/runtime/lua",
+          },
         },
         telemetry = { enable = false },
       },

--- a/.config/nvim/lua/currentuser/remap.lua
+++ b/.config/nvim/lua/currentuser/remap.lua
@@ -3,6 +3,7 @@ vim.keymap.set("n", "<leader>e", vim.cmd.Ex)
 vim.keymap.set("n", "<leader>r", vim.cmd.Rex)
 vim.keymap.set("n", ";", ":")
 vim.keymap.set("n", "<leader>jd", ":lua vim.lsp.buf.definition()\n")
+vim.keymap.set("n", "<leader>fl", ":lua vim.diagnostic.open_float()\n")
 
 -- Enclose word in normal mode 
 vim.keymap.set("n", "<leader>(", "viwdi()<C-[>hp")


### PR DESCRIPTION
In this PR:
- set up Lua LSP in the `init.lua`
- added checks for Lua and Go to only attempt connecting LSPs if the actual language servers are installed
- added `fl` remap to open error and warning messages using `open_float()` function